### PR TITLE
variable name explanation mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ buenos_map = folium.Map([-34.6037, -58.3816])
 buenos_map
 ```
 
-> [Folium](https://github.com/python-visualization/folium) is a mapping library built on Python.  We created a representation of a map, by referencing the `folium.Map` function and passing through a list.  That list represents the latitude and longitude, just like we saw previously.  The map object is stored as the variable `buenos`.  Since `buenos` is the last line of a cell, the map is displayed.
+> [Folium](https://github.com/python-visualization/folium) is a mapping library built on Python.  We created a representation of a map, by referencing the `folium.Map` function and passing through a list.  That list represents the latitude and longitude, just like we saw previously.  The map object is stored as the variable `buenos_map`.  Since `buenos_map` is the last line of a cell, the map is displayed.
 
 Now we can also add a marker to this map.
 


### PR DESCRIPTION
In the explanation text, the map object is stored as the variable 'buenos_map' not as 'buenos'
